### PR TITLE
feat: add .env configuration support and validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,191 @@
+# Copy this file to ".env" and edit values as needed.
+# Precedence: CLI args > .env > code defaults
+
+# ------------------------------
+# Common (recommended)
+# ------------------------------
+
+# Path to the pretrained model directory or HF model id
+MODEL_PATH=/path/to/model
+
+# Number of GPUs to use (must be > 0)
+N_GPUS=8
+
+# Base directories (used for your own organization; some scripts use DATA_PATH/OUTPUT_PATH instead)
+DATA_DIR=/path/to/data
+OUTPUT_DIR=/path/to/output
+
+# ------------------------------
+# Common paths (used by multiple scripts)
+# ------------------------------
+
+# Many entry scripts accept these as required CLI args; setting them here can remove the need to pass them every time.
+# Note: empty strings are treated as "unset" by the loader helpers (so `DATA_PATH=` behaves like not set).
+#
+# Prefer the namespaced variables below when you run multiple scripts from the same `.env` to avoid collisions.
+DATA_PATH=
+OUTPUT_PATH=
+
+# Optional tokenizer path (defaults to MODEL_PATH in some scripts)
+TOKENIZER_PATH=
+
+# Model dtype (example: bfloat16, float16)
+DTYPE=bfloat16
+
+# ------------------------------
+# infer_split_merge.py (problem generation / split-and-merge)
+# ------------------------------
+# Prefer these namespaced vars to avoid collisions across scripts.
+SPLIT_MERGE_DATA_PATH=
+SPLIT_MERGE_OUTPUT_PATH=
+SPLIT_MERGE_MODEL_PATH=
+SPLIT_MERGE_TOKENIZER_PATH=
+SPLIT_MERGE_DTYPE=bfloat16
+SPLIT_MERGE_N_GPUS=8
+SPLIT_MERGE_N_SPLITS=4
+SPLIT_MERGE_TEMPERATURE=0.0
+SPLIT_MERGE_TOP_P=1.0
+SPLIT_MERGE_TOP_K=-1
+SPLIT_MERGE_PRESENCE_PENALTY=0.0
+SPLIT_MERGE_FREQUENCY_PENALTY=0.0
+SPLIT_MERGE_REPETITION_PENALTY=1.0
+SPLIT_MERGE_MIN_LEN=0
+SPLIT_MERGE_MAX_LEN=2048
+SPLIT_MERGE_USE_CHAT_TEMPLATE=false
+SPLIT_MERGE_SEED=-1
+SPLIT_MERGE_USE_MAMBA2=false
+SPLIT_MERGE_GPU_MEMORY_UTILIZATION=0.9
+SPLIT_MERGE_MAX_NUM_SEQS=256
+SPLIT_MERGE_FACTOR=1.0
+SPLIT_MERGE_ORIGINAL_MAX_POSITION_EMBEDDINGS=131072
+SPLIT_MERGE_EXPECTED_RUNS=1
+SPLIT_MERGE_REASONING_EFFORT=
+SPLIT_MERGE_DEBUG=false
+
+# Back-compat (unprefixed). infer_split_merge.py reads N_SPLITS (and also falls back to NUM_SPLITS).
+N_SPLITS=4
+TEMPERATURE=0.0
+TOP_P=1.0
+TOP_K=-1
+PRESENCE_PENALTY=0.0
+FREQUENCY_PENALTY=0.0
+REPETITION_PENALTY=1.0
+MIN_LEN=0
+MAX_LEN=2048
+USE_CHAT_TEMPLATE=false
+SEED=-1
+USE_MAMBA2=false
+GPU_MEMORY_UTILIZATION=0.9
+MAX_NUM_SEQS=256
+FACTOR=1.0
+ORIGINAL_MAX_POSITION_EMBEDDINGS=131072
+EXPECTED_RUNS=1
+REASONING_EFFORT=
+DEBUG=false
+
+# ------------------------------
+# infer_self_play.py
+# ------------------------------
+# Prefer these namespaced vars to avoid collisions across scripts.
+SELF_PLAY_DATA_PATH=
+SELF_PLAY_OUTPUT_PATH=
+SELF_PLAY_MODEL_PATH=
+SELF_PLAY_DTYPE=bfloat16
+SELF_PLAY_N_GPUS=8
+SELF_PLAY_NUM_SPLITS=4
+SELF_PLAY_NUM_COMPLETIONS=1
+SELF_PLAY_TEMPERATURE=0.0
+SELF_PLAY_TOP_P=1.0
+SELF_PLAY_MAX_LEN=2048
+SELF_PLAY_USE_CHAT_TEMPLATE=false
+SELF_PLAY_SEED=0
+SELF_PLAY_USE_MAMBA2=false
+SELF_PLAY_TRUST_REMOTE_CODE=false
+SELF_PLAY_REASONING_EFFORT=
+SELF_PLAY_DEBUG=false
+
+# Back-compat (unprefixed). infer_self_play.py reads NUM_SPLITS (and also falls back to N_SPLITS).
+NUM_SPLITS=4
+NUM_COMPLETIONS=1
+TRUST_REMOTE_CODE=false
+
+# ------------------------------
+# test_cases_generation.py
+# ------------------------------
+TEST_CASES_GEN_DATA_PATH=
+TEST_CASES_GEN_OUTPUT_PATH=
+TEST_CASES_GEN_MODEL_PATH=
+TEST_CASES_GEN_TOKENIZER_PATH=
+TEST_CASES_GEN_DTYPE=bfloat16
+TEST_CASES_GEN_N_GPUS=8
+TEST_CASES_GEN_TEMPERATURE=0.0
+TEST_CASES_GEN_TOP_P=1.0
+TEST_CASES_GEN_TOP_K=-1
+TEST_CASES_GEN_MAX_LEN=2048
+TEST_CASES_GEN_USE_CHAT_TEMPLATE=false
+TEST_CASES_GEN_SEED=42
+TEST_CASES_GEN_ENABLE_THINKING=true
+
+ENABLE_THINKING=true
+
+# ------------------------------
+# self_play_eval.py
+# ------------------------------
+SELF_PLAY_EVAL_DATA_PATH=
+SELF_PLAY_EVAL_OUTPUT_PATH=
+SELF_PLAY_EVAL_TYPE=code
+SELF_PLAY_EVAL_NUM_WORKERS=4
+SELF_PLAY_EVAL_MAX_ITEMS=
+SELF_PLAY_EVAL_DEBUG=false
+
+EVAL_TYPE=code
+NUM_WORKERS=4
+MAX_ITEMS=
+
+# ------------------------------
+# deduplicate_problems.py
+# ------------------------------
+# Prefer these namespaced vars to avoid collisions across scripts.
+DEDUP_PATTERN=output/promptcot_2_0_code_problems_{}.jsonl
+DEDUP_INDICES=0-64
+DEDUP_EXCLUDE=
+DEDUP_OUTPUT=output/promptcot_2_0_code_problems_deduplicated.jsonl
+DEDUP_TASK_TYPE=code
+DEDUP_THRESHOLD=0.2
+DEDUP_MIN_WORD_LENGTH=4
+
+# Back-compat (unprefixed).
+PATTERN=output/promptcot_2_0_code_problems_{}.jsonl
+INDICES=0-64
+EXCLUDE=
+TASK_TYPE=code
+THRESHOLD=0.2
+MIN_WORD_LENGTH=4
+
+# ------------------------------
+# test_cases_postprocess.py
+# ------------------------------
+TEST_CASES_POSTPROCESS_INPUT_FILE=
+TEST_CASES_POSTPROCESS_OUTPUT_FILE=
+INPUT_FILE=
+OUTPUT_FILE=
+
+# ------------------------------
+# prepare_self_play_data.py
+# ------------------------------
+PREPARE_SELF_PLAY_DATA_DATA_PATH=
+PREPARE_SELF_PLAY_DATA_OUTPUT_PATH=
+
+# ------------------------------
+# prepare_sft_data_code.py
+# ------------------------------
+PREPARE_SFT_DATA_CODE_DATA_PATH=
+PREPARE_SFT_DATA_CODE_OUTPUT_PATH=
+PREPARE_SFT_DATA_CODE_TOKENIZER_PATH=
+PREPARE_SFT_DATA_CODE_MIN_LEN=0
+PREPARE_SFT_DATA_CODE_MAX_LEN=16384
+
+# ------------------------------
+# Optional database config (validate_config.py)
+# ------------------------------
+# DB_URI=sqlite:////absolute/path/to/db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ pip install -r requirements.txt
 
 ---
 
+## Configuration
+
+Top-level scripts support loading default configuration values from a local `.env` file.
+
+1. Copy `.env.example` to `.env`
+2. Edit values (for example `MODEL_PATH`, `N_GPUS`, `DATA_PATH`, `OUTPUT_PATH`)
+3. Validate your setup:
+
+```bash
+python validate_config.py
+```
+
+Notes:
+- Precedence is `CLI args > .env > code defaults`.
+- `MODEL_PATH` / `TOKENIZER_PATH` can be a local path or a Hugging Face model id; the validator only checks filesystem paths.
+- Empty strings in `.env` are treated as "unset" (e.g. `DATA_PATH=` behaves like not set).
+- Prefer namespaced environment variables (e.g. `SPLIT_MERGE_OUTPUT_PATH`, `SELF_PLAY_OUTPUT_PATH`) to avoid collisions when you run multiple scripts from the same `.env`.
+- Some scripts historically used different env var names (e.g. `infer_split_merge.py` uses `N_SPLITS`, while `infer_self_play.py` uses `NUM_SPLITS`); `.env.example` documents the mapping and the code includes small fallbacks for these.
+
+To run the lightweight unit tests in this repo:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+---
+
 ## 🧩 Problem Generation (Concept → Rationale → Problem)
 
 We provide a script to synthesize problems from concept files using the PromptCoT 2.0 pipeline.
@@ -419,4 +446,3 @@ If you find the **PromptCoT** series useful, please consider citing our work:
   url       = {https://arxiv.org/abs/2503.02324}
 }
 ````
-

--- a/deduplicate_problems.py
+++ b/deduplicate_problems.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from tqdm import tqdm
 from utils import DuplicateChecker
 
+from env_config import load_env, env_float, env_int, env_str
+
 
 """
 Deduplicate problems across multiple JSONL shards.
@@ -99,6 +101,8 @@ def write_results(results, output_file):
 
 
 def main():
+    load_env()
+
     parser = argparse.ArgumentParser(
         description="Deduplicate problems from JSONL files",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -135,17 +139,22 @@ Notes:
         """
     )
 
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    pattern_default = env_str("DEDUP_PATTERN") or env_str("PATTERN")
     parser.add_argument(
         "--pattern",
         type=str,
-        required=True,
+        default=pattern_default,
+        required=pattern_default is None,
         help="File pattern with a `{}` placeholder for the shard index (e.g., 'data/trace{}.jsonl')."
     )
 
+    indices_default = env_str("DEDUP_INDICES") or env_str("INDICES")
     parser.add_argument(
         "--indices",
         type=str,
-        required=True,
+        default=indices_default,
+        required=indices_default is None,
         help=(
             "Indices to process, as comma-separated values and/or ranges. "
             "Ranges are end-exclusive (e.g., '0-60' means 0..59). "
@@ -156,14 +165,16 @@ Notes:
     parser.add_argument(
         "--exclude",
         type=str,
-        default="",
+        default=env_str("DEDUP_EXCLUDE") or env_str("EXCLUDE", default=""),
         help="Comma-separated indices to exclude (e.g., '0,2,5').",
     )
 
+    output_default = env_str("DEDUP_OUTPUT") or env_str("OUTPUT")
     parser.add_argument(
         "--output",
         type=str,
-        required=True,
+        default=output_default,
+        required=output_default is None,
         help="Output JSONL path (e.g., 'output/deduplicated.jsonl').",
     )
 
@@ -171,23 +182,21 @@ Notes:
         "--task-type",
         type=str,
         choices=["code", "math"],
-        default="code",
+        default=env_str("DEDUP_TASK_TYPE") or env_str("TASK_TYPE", default="code"),
         help="Prompt formatting for output items: 'code' or 'math' (default: code).",
     )
 
     parser.add_argument(
         "--threshold",
         type=float,
-        default=0.2,
-        help=(
-            "Fuzzy duplicate threshold (lower is more aggressive; default: 0.2)."
-        ),
+        default=env_float("DEDUP_THRESHOLD", default=None) or env_float("THRESHOLD", default=0.2),
+        help="Fuzzy duplicate threshold (lower is more aggressive; default: 0.2).",
     )
 
     parser.add_argument(
         "--min-word-length",
         type=int,
-        default=4,
+        default=env_int("DEDUP_MIN_WORD_LENGTH", default=None) or env_int("MIN_WORD_LENGTH", default=4),
         help="Minimum word length considered for fuzzy duplicate detection (default: 4).",
     )
 

--- a/env_config.py
+++ b/env_config.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+from typing import Optional, Mapping
+
+__all__ = [
+    "env_bool",
+    "env_float",
+    "env_int",
+    "env_present",
+    "env_str",
+    "load_env",
+]
+
+
+def load_env(dotenv_path: Optional[str] = None, override: bool = False) -> bool:
+    """
+    Load environment variables from a local .env file (if python-dotenv is installed).
+
+    Precedence is preserved naturally:
+    - CLI args override .env because argparse uses explicit argv values
+    - .env overrides code defaults by supplying argparse defaults
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return False
+
+    return bool(load_dotenv(dotenv_path=dotenv_path, override=override))
+
+
+def _raw_env(name: str, environ: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    env = environ if environ is not None else os.environ
+    val = env.get(name)
+    if val is None:
+        return None
+    val = val.strip()
+    return val or None
+
+
+def env_str(name: str, default: Optional[str] = None, *, environ: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    return _raw_env(name, environ=environ) or default
+
+
+def env_int(name: str, default: Optional[int] = None, *, environ: Optional[Mapping[str, str]] = None) -> Optional[int]:
+    raw = _raw_env(name, environ=environ)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        # This is usually used for argparse defaults; fail fast without a noisy traceback.
+        raise SystemExit(f"Invalid integer environment variable {name}={raw!r}")
+
+
+def env_float(name: str, default: Optional[float] = None, *, environ: Optional[Mapping[str, str]] = None) -> Optional[float]:
+    raw = _raw_env(name, environ=environ)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        raise SystemExit(f"Invalid float environment variable {name}={raw!r}")
+
+
+def env_bool(name: str, default: Optional[bool] = None, *, environ: Optional[Mapping[str, str]] = None) -> Optional[bool]:
+    raw = _raw_env(name, environ=environ)
+    if raw is None:
+        return default
+    lowered = raw.lower()
+    if lowered in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if lowered in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    raise SystemExit(
+        f"Invalid boolean environment variable {name}={raw!r} (expected one of: "
+        "1/0, true/false, yes/no, on/off)"
+    )
+
+
+def env_present(name: str, *, environ: Optional[Mapping[str, str]] = None) -> bool:
+    return _raw_env(name, environ=environ) is not None

--- a/infer_self_play.py
+++ b/infer_self_play.py
@@ -7,6 +7,8 @@ import math
 from typing import List, Dict
 import time
 
+from env_config import load_env, env_bool, env_float, env_int, env_str
+
 
 def get_after_think(text):
     parts = text.split("</think>", 1)
@@ -196,24 +198,38 @@ def main():
     import torch
     from str2bool import str2bool
 
+    load_env()
+
     parser = argparse.ArgumentParser(
         description="Generate completions for large language models using split-and-merge.")
-    parser.add_argument("--data_path", type=str, required=True, help="Path to the dataset file.")
-    parser.add_argument("--output_path", type=str, required=True, help="Directory to store cached outputs.")
-    parser.add_argument("--model_path", type=str, required=True, help="Path to the pretrained model.")
-    parser.add_argument("--dtype", type=str, default="bfloat16", help="Data type to use for the model.")
-    parser.add_argument("--n_gpus", type=int, default=8, help="Total number of GPUs to use.")
-    parser.add_argument("--num_splits", type=int, default=4, help="Number of data splits/parallel processes.")
-    parser.add_argument("--num_completions", type=int, default=1, help="Number of completions to generate per item.")
-    parser.add_argument("--temperature", type=float, default=0.0, help="Sampling temperature for generation.")
-    parser.add_argument("--top_p", type=float, default=1.0, help="Top-p sampling for generation.")
-    parser.add_argument("--max_len", type=int, default=2048, help="Maximum number of tokens to generate.")
-    parser.add_argument("--use_chat_template", type=str2bool, default=False)
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--use_mamba2", type=str2bool, default=False)
-    parser.add_argument("--trust_remote_code", type=str2bool, default=False)
-    parser.add_argument("--reasoning_effort", type=str, default=None)
-    parser.add_argument("--debug", type=str2bool, default=False)
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    data_path_default = env_str("SELF_PLAY_DATA_PATH") or env_str("DATA_PATH")
+    output_path_default = env_str("SELF_PLAY_OUTPUT_PATH") or env_str("OUTPUT_PATH")
+    model_path_default = env_str("SELF_PLAY_MODEL_PATH") or env_str("MODEL_PATH")
+    parser.add_argument("--data_path", type=str, default=data_path_default, required=data_path_default is None, help="Path to the dataset file.")
+    parser.add_argument("--output_path", type=str, default=output_path_default, required=output_path_default is None, help="Directory to store cached outputs.")
+    parser.add_argument("--model_path", type=str, default=model_path_default, required=model_path_default is None, help="Path to the pretrained model.")
+    parser.add_argument("--dtype", type=str, default=env_str("SELF_PLAY_DTYPE") or env_str("DTYPE", default="bfloat16"), help="Data type to use for the model.")
+    n_gpus_default = env_int("SELF_PLAY_N_GPUS", default=None)
+    if n_gpus_default is None:
+        n_gpus_default = env_int("N_GPUS", default=8)
+    parser.add_argument("--n_gpus", type=int, default=n_gpus_default, help="Total number of GPUs to use.")
+    num_splits_default = env_int("SELF_PLAY_NUM_SPLITS", default=None)
+    if num_splits_default is None:
+        num_splits_default = env_int("NUM_SPLITS", default=None)
+    if num_splits_default is None:
+        num_splits_default = env_int("N_SPLITS", default=4)
+    parser.add_argument("--num_splits", type=int, default=num_splits_default, help="Number of data splits/parallel processes.")
+    parser.add_argument("--num_completions", type=int, default=env_int("SELF_PLAY_NUM_COMPLETIONS", default=None) or env_int("NUM_COMPLETIONS", default=1), help="Number of completions to generate per item.")
+    parser.add_argument("--temperature", type=float, default=env_float("SELF_PLAY_TEMPERATURE", default=None) or env_float("TEMPERATURE", default=0.0), help="Sampling temperature for generation.")
+    parser.add_argument("--top_p", type=float, default=env_float("SELF_PLAY_TOP_P", default=None) or env_float("TOP_P", default=1.0), help="Top-p sampling for generation.")
+    parser.add_argument("--max_len", type=int, default=env_int("SELF_PLAY_MAX_LEN", default=None) or env_int("MAX_LEN", default=2048), help="Maximum number of tokens to generate.")
+    parser.add_argument("--use_chat_template", type=str2bool, default=env_bool("SELF_PLAY_USE_CHAT_TEMPLATE", default=None) or env_bool("USE_CHAT_TEMPLATE", default=False))
+    parser.add_argument("--seed", type=int, default=env_int("SELF_PLAY_SEED", default=None) or env_int("SEED", default=0))
+    parser.add_argument("--use_mamba2", type=str2bool, default=env_bool("SELF_PLAY_USE_MAMBA2", default=None) or env_bool("USE_MAMBA2", default=False))
+    parser.add_argument("--trust_remote_code", type=str2bool, default=env_bool("SELF_PLAY_TRUST_REMOTE_CODE", default=None) or env_bool("TRUST_REMOTE_CODE", default=False))
+    parser.add_argument("--reasoning_effort", type=str, default=env_str("SELF_PLAY_REASONING_EFFORT") or env_str("REASONING_EFFORT", default=None))
+    parser.add_argument("--debug", type=str2bool, default=env_bool("SELF_PLAY_DEBUG", default=None) or env_bool("DEBUG", default=False))
 
     args = parser.parse_args()
 

--- a/infer_split_merge.py
+++ b/infer_split_merge.py
@@ -7,6 +7,8 @@ import math
 from typing import List, Dict, Any
 import time
 
+from env_config import load_env, env_bool, env_float, env_int, env_str
+
 
 """
 Run vLLM inference over a JSONL dataset.
@@ -189,125 +191,222 @@ def main():
     import torch
     from str2bool import str2bool
 
+    load_env()
+
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    data_path_default = env_str("SPLIT_MERGE_DATA_PATH") or env_str("DATA_PATH")
+    output_path_default = env_str("SPLIT_MERGE_OUTPUT_PATH") or env_str("OUTPUT_PATH")
+    model_path_default = env_str("SPLIT_MERGE_MODEL_PATH") or env_str("MODEL_PATH")
+    tokenizer_path_default = (
+        env_str("SPLIT_MERGE_TOKENIZER_PATH")
+        or env_str("TOKENIZER_PATH", default=None)
+    )
+
+    dtype_default = env_str("SPLIT_MERGE_DTYPE") or env_str("DTYPE", default="bfloat16")
+    n_gpus_default = env_int("SPLIT_MERGE_N_GPUS", default=None)
+    if n_gpus_default is None:
+        n_gpus_default = env_int("N_GPUS", default=8)
+
+    n_splits_default = env_int("SPLIT_MERGE_N_SPLITS", default=None)
+    if n_splits_default is None:
+        n_splits_default = env_int("N_SPLITS", default=None)
+    if n_splits_default is None:
+        n_splits_default = env_int("NUM_SPLITS", default=4)
+
+    temperature_default = env_float("SPLIT_MERGE_TEMPERATURE", default=None)
+    if temperature_default is None:
+        temperature_default = env_float("TEMPERATURE", default=0.0)
+
+    top_p_default = env_float("SPLIT_MERGE_TOP_P", default=None)
+    if top_p_default is None:
+        top_p_default = env_float("TOP_P", default=1.0)
+
+    top_k_default = env_int("SPLIT_MERGE_TOP_K", default=None)
+    if top_k_default is None:
+        top_k_default = env_int("TOP_K", default=-1)
+
+    presence_penalty_default = env_float("SPLIT_MERGE_PRESENCE_PENALTY", default=None)
+    if presence_penalty_default is None:
+        presence_penalty_default = env_float("PRESENCE_PENALTY", default=0.0)
+
+    frequency_penalty_default = env_float("SPLIT_MERGE_FREQUENCY_PENALTY", default=None)
+    if frequency_penalty_default is None:
+        frequency_penalty_default = env_float("FREQUENCY_PENALTY", default=0.0)
+
+    repetition_penalty_default = env_float("SPLIT_MERGE_REPETITION_PENALTY", default=None)
+    if repetition_penalty_default is None:
+        repetition_penalty_default = env_float("REPETITION_PENALTY", default=1.0)
+
+    min_len_default = env_int("SPLIT_MERGE_MIN_LEN", default=None)
+    if min_len_default is None:
+        min_len_default = env_int("MIN_LEN", default=0)
+
+    max_len_default = env_int("SPLIT_MERGE_MAX_LEN", default=None)
+    if max_len_default is None:
+        max_len_default = env_int("MAX_LEN", default=2048)
+
+    use_chat_template_default = env_bool("SPLIT_MERGE_USE_CHAT_TEMPLATE", default=None)
+    if use_chat_template_default is None:
+        use_chat_template_default = env_bool("USE_CHAT_TEMPLATE", default=False)
+
+    seed_default = env_int("SPLIT_MERGE_SEED", default=None)
+    if seed_default is None:
+        seed_default = env_int("SEED", default=-1)
+
+    use_mamba2_default = env_bool("SPLIT_MERGE_USE_MAMBA2", default=None)
+    if use_mamba2_default is None:
+        use_mamba2_default = env_bool("USE_MAMBA2", default=False)
+
+    gpu_memory_utilization_default = env_float("SPLIT_MERGE_GPU_MEMORY_UTILIZATION", default=None)
+    if gpu_memory_utilization_default is None:
+        gpu_memory_utilization_default = env_float("GPU_MEMORY_UTILIZATION", default=0.9)
+
+    max_num_seqs_default = env_int("SPLIT_MERGE_MAX_NUM_SEQS", default=None)
+    if max_num_seqs_default is None:
+        max_num_seqs_default = env_int("MAX_NUM_SEQS", default=256)
+
+    factor_default = env_float("SPLIT_MERGE_FACTOR", default=None)
+    if factor_default is None:
+        factor_default = env_float("FACTOR", default=1.0)
+
+    original_max_pos_default = env_int("SPLIT_MERGE_ORIGINAL_MAX_POSITION_EMBEDDINGS", default=None)
+    if original_max_pos_default is None:
+        original_max_pos_default = env_int("ORIGINAL_MAX_POSITION_EMBEDDINGS", default=131072)
+
+    expected_runs_default = env_int("SPLIT_MERGE_EXPECTED_RUNS", default=None)
+    if expected_runs_default is None:
+        expected_runs_default = env_int("EXPECTED_RUNS", default=1)
+
+    reasoning_effort_default = env_str("SPLIT_MERGE_REASONING_EFFORT")
+    if reasoning_effort_default is None:
+        reasoning_effort_default = env_str("REASONING_EFFORT", default=None)
+
+    debug_default = env_bool("SPLIT_MERGE_DEBUG", default=None)
+    if debug_default is None:
+        debug_default = env_bool("DEBUG", default=False)
+
     parser = argparse.ArgumentParser(description="Generate completions using split-and-merge with vLLM.")
     parser.add_argument(
         "--data_path",
         type=str,
-        required=True,
+        default=data_path_default,
+        required=data_path_default is None,
         help="Path to the dataset file (JSONL with a `prompt` field).",
     )
     parser.add_argument(
         "--output_path",
         type=str,
-        required=True,
+        default=output_path_default,
+        required=output_path_default is None,
         help="Output JSONL path.",
     )
     parser.add_argument(
         "--model_path",
         type=str,
-        required=True,
+        default=model_path_default,
+        required=model_path_default is None,
         help="Path to the pretrained model.",
     )
     parser.add_argument(
         "--tokenizer_path",
         type=str,
-        default=None,
+        default=tokenizer_path_default,
         help="Tokenizer path (defaults to --model_path).",
     )
     parser.add_argument(
         "--dtype",
         type=str,
-        default="bfloat16",
+        default=dtype_default,
         help="Data type to use for the model.",
     )
     parser.add_argument(
         "--n_gpus",
         type=int,
-        default=8,
+        default=n_gpus_default,
         help="Total number of GPUs to use.",
     )
     parser.add_argument(
         "--n_splits",
         type=int,
-        default=4,
+        default=n_splits_default,
         help="Number of data splits/parallel processes.",
     )
     parser.add_argument(
         "--temperature",
         type=float,
-        default=0.0,
+        default=temperature_default,
         help="Sampling temperature for generation.",
     )
     parser.add_argument(
         "--top_p",
         type=float,
-        default=1.0,
+        default=top_p_default,
         help="Top-p sampling for generation.",
     )
     parser.add_argument(
         "--top_k",
         type=int,
-        default=-1,
+        default=top_k_default,
         help="Top-k sampling for generation (-1 disables).",
     )
     parser.add_argument(
         "--presence_penalty",
         type=float,
-        default=0.0,
+        default=presence_penalty_default,
         help="Presence penalty for sampling.",
     )
     parser.add_argument(
         "--frequency_penalty",
         type=float,
-        default=0.0,
+        default=frequency_penalty_default,
         help="Frequency penalty for sampling.",
     )
     parser.add_argument(
         "--repetition_penalty",
         type=float,
-        default=1.0,
+        default=repetition_penalty_default,
         help="Repetition penalty for sampling.",
     )
     parser.add_argument(
         "--min_len",
         type=int,
-        default=0,
+        default=min_len_default,
         help="Minimum number of tokens to generate.",
     )
     parser.add_argument(
         "--max_len",
         type=int,
-        default=2048,
+        default=max_len_default,
         help="Maximum number of tokens to generate.",
     )
     parser.add_argument(
         "--use_chat_template",
         type=str2bool,
-        default=False,
+        default=use_chat_template_default,
         help="Whether to apply chat template to prompts.",
     )
     parser.add_argument(
         "--seed",
         type=int,
-        default=-1,
+        default=seed_default,
         help="Seed for sampling (-1 for non-deterministic). When --expected_runs > 1, seed must be -1 (non-deterministic).",
     )
     parser.add_argument(
         "--use_mamba2",
         type=str2bool,
-        default=False,
+        default=use_mamba2_default,
         help="Whether to use the Mamba2 variant code path.",
     )
     parser.add_argument(
         "--gpu_memory_utilization",
         type=float,
-        default=0.9,
+        default=gpu_memory_utilization_default,
         help="GPU memory utilization for vLLM.",
     )
     parser.add_argument(
         "--max_num_seqs",
         type=int,
-        default=256,
+        default=max_num_seqs_default,
         help="vLLM max_num_seqs (used when --use_mamba2 is true).",
     )
 
@@ -315,32 +414,32 @@ def main():
     parser.add_argument(
         "--factor",
         type=float,
-        default=1.0,
+        default=factor_default,
         help="RoPE scaling factor (YARN).",
     )
     parser.add_argument(
         "--original_max_position_embeddings",
         type=int,
-        default=131072,
+        default=original_max_pos_default,
         help="Original max position embeddings (used when --factor > 1.0).",
     )
 
     parser.add_argument(
         "--expected_runs",
         type=int,
-        default=1,
+        default=expected_runs_default,
         help="Number of completions to generate per item (expanded by repetition).",
     )
     parser.add_argument(
         "--reasoning_effort",
         type=str,
-        default=None,
+        default=reasoning_effort_default,
         help="Optional arg passed to tokenizer chat template (requires --use_chat_template).",
     )
     parser.add_argument(
         "--debug",
         type=str2bool,
-        default=False,
+        default=debug_default,
         help="If true, only process a small subset for quick debugging.",
     )
 

--- a/prepare_self_play_data.py
+++ b/prepare_self_play_data.py
@@ -7,11 +7,15 @@ import argparse
 from utils import load_test_problems, fix_qwq_completion, get_after_think
 from eval.qwen_math import extract_answer, strip_string
 
+from env_config import load_env, env_str
+
 
 if __name__ == "__main__":
+    load_env()
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data_path", type=str, default="")
-    parser.add_argument("--output_path", type=str, default="")
+    parser.add_argument("--data_path", type=str, default=env_str("PREPARE_SELF_PLAY_DATA_DATA_PATH") or env_str("DATA_PATH", default=""))
+    parser.add_argument("--output_path", type=str, default=env_str("PREPARE_SELF_PLAY_DATA_OUTPUT_PATH") or env_str("OUTPUT_PATH", default=""))
 
     args = parser.parse_args()
 

--- a/prepare_sft_data_code.py
+++ b/prepare_sft_data_code.py
@@ -7,6 +7,8 @@ from functools import partial
 from utils import fix_gptoss_completion, get_after_think
 from transformers import AutoTokenizer
 
+from env_config import load_env, env_int, env_str
+
 
 def qwq_prompt(problem):
     """Generate prompt template for QWQ model."""
@@ -71,12 +73,17 @@ def process_item_batch(items_batch, tokenizer_path, max_len, min_len):
 
 
 if __name__ == "__main__":
+    load_env()
+
     parser = argparse.ArgumentParser(description='Process data files for training')
-    parser.add_argument('--data_path', type=str, required=True, help='Input data file path')
-    parser.add_argument('--output_path', type=str, required=True, help='Output file path')
-    parser.add_argument('--tokenizer_path', type=str, default="/personal/xueliang/hf_models/Qwen2.5-7B-Instruct", help='Tokenizer path')
-    parser.add_argument('--min_len', type=int, default=0, help='Minimum token length')
-    parser.add_argument('--max_len', type=int, default=16384, help='Maximum token length')
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    data_path_default = env_str("PREPARE_SFT_DATA_CODE_DATA_PATH") or env_str("DATA_PATH")
+    output_path_default = env_str("PREPARE_SFT_DATA_CODE_OUTPUT_PATH") or env_str("OUTPUT_PATH")
+    parser.add_argument('--data_path', type=str, default=data_path_default, required=data_path_default is None, help='Input data file path')
+    parser.add_argument('--output_path', type=str, default=output_path_default, required=output_path_default is None, help='Output file path')
+    parser.add_argument('--tokenizer_path', type=str, default=env_str("PREPARE_SFT_DATA_CODE_TOKENIZER_PATH") or env_str("TOKENIZER_PATH", default="/personal/xueliang/hf_models/Qwen2.5-7B-Instruct"), help='Tokenizer path')
+    parser.add_argument('--min_len', type=int, default=env_int("PREPARE_SFT_DATA_CODE_MIN_LEN", default=None) or env_int("MIN_LEN", default=0), help='Minimum token length')
+    parser.add_argument('--max_len', type=int, default=env_int("PREPARE_SFT_DATA_CODE_MAX_LEN", default=None) or env_int("MAX_LEN", default=16384), help='Maximum token length')
 
     args = parser.parse_args()
 

--- a/self_play_eval.py
+++ b/self_play_eval.py
@@ -10,6 +10,8 @@ import numpy as np
 import threading
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 
+from env_config import load_env, env_bool, env_int, env_str
+
 
 def extract_code(text: str) -> str:
     outputlines = text.split("\n")
@@ -253,14 +255,20 @@ def test_item_completions(item: Dict, num_workers: int, eval_type: str) -> Dict:
 def main():
     from str2bool import str2bool
 
+    load_env()
+
     parser = argparse.ArgumentParser(
         description="Run test cases on generated completions.")
-    parser.add_argument("--data_path", type=str, required=True, help="Path to the dataset file with completions.")
-    parser.add_argument("--output_path", type=str, required=True, help="Path to store results.")
-    parser.add_argument("--eval_type", type=str, required=True, choices=["code", "math"], help="Type of evaluation: 'code' for code testing or 'math' for math equivalence")
-    parser.add_argument("--num_workers", type=int, default=4, help="Number of concurrent workers for test execution.")
-    parser.add_argument("--max_items", type=int, default=None, help="Maximum number of items to process (for debugging).")
-    parser.add_argument("--debug", type=str2bool, default=False)
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    data_path_default = env_str("SELF_PLAY_EVAL_DATA_PATH") or env_str("DATA_PATH")
+    output_path_default = env_str("SELF_PLAY_EVAL_OUTPUT_PATH") or env_str("OUTPUT_PATH")
+    eval_type_default = env_str("SELF_PLAY_EVAL_TYPE") or env_str("EVAL_TYPE")
+    parser.add_argument("--data_path", type=str, default=data_path_default, required=data_path_default is None, help="Path to the dataset file with completions.")
+    parser.add_argument("--output_path", type=str, default=output_path_default, required=output_path_default is None, help="Path to store results.")
+    parser.add_argument("--eval_type", type=str, default=eval_type_default, required=eval_type_default is None, choices=["code", "math"], help="Type of evaluation: 'code' for code testing or 'math' for math equivalence")
+    parser.add_argument("--num_workers", type=int, default=env_int("SELF_PLAY_EVAL_NUM_WORKERS", default=None) or env_int("NUM_WORKERS", default=4), help="Number of concurrent workers for test execution.")
+    parser.add_argument("--max_items", type=int, default=env_int("SELF_PLAY_EVAL_MAX_ITEMS", default=None) or env_int("MAX_ITEMS", default=None), help="Maximum number of items to process (for debugging).")
+    parser.add_argument("--debug", type=str2bool, default=env_bool("SELF_PLAY_EVAL_DEBUG", default=None) or env_bool("DEBUG", default=False))
 
     args = parser.parse_args()
 

--- a/test_cases_generation.py
+++ b/test_cases_generation.py
@@ -6,6 +6,8 @@ from transformers import AutoTokenizer
 from str2bool import str2bool
 import os
 
+from env_config import load_env, env_bool, env_float, env_int, env_str
+
 def test_case_generation_prompt(prompt_text):
 
     refined_prompt = (
@@ -49,20 +51,26 @@ def test_case_generation_prompt(prompt_text):
     return refined_prompt
 
 def main():
+    load_env()
+
     parser = argparse.ArgumentParser(description="Evaluate large language models on critical datasets.")
-    parser.add_argument("--data_path", type=str, required=True, help="Path to the dataset file.")
-    parser.add_argument("--output_path", type=str, required=True, help="Directory to store cached outputs.")
-    parser.add_argument("--model_path", type=str, required=True, help="Path to the pretrained model.")
-    parser.add_argument("--tokenizer_path", type=str, default=None, help="Path to the pretrained model.")
-    parser.add_argument("--dtype", type=str, default="bfloat16", help="Data type to use for the model (e.g., fp16, bf16, etc.).")
-    parser.add_argument("--n_gpus", type=int, default=8, help="Number of GPUs to use for tensor parallelism.")
-    parser.add_argument("--temperature", type=float, default=0.0, help="Sampling temperature for generation.")
-    parser.add_argument("--top_p", type=float, default=1.0, help="Top-p sampling for generation.")
-    parser.add_argument("--top_k", type=int, default=-1, help="Top-k sampling for generation.")  # todo: 40
-    parser.add_argument("--max_len", type=int, default=2048, help="Maximum number of tokens to generate.")
-    parser.add_argument("--use_chat_template", type=str2bool, default=False)
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--enable_thinking", type=str2bool, default=True)
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    data_path_default = env_str("TEST_CASES_GEN_DATA_PATH") or env_str("DATA_PATH")
+    output_path_default = env_str("TEST_CASES_GEN_OUTPUT_PATH") or env_str("OUTPUT_PATH")
+    model_path_default = env_str("TEST_CASES_GEN_MODEL_PATH") or env_str("MODEL_PATH")
+    parser.add_argument("--data_path", type=str, default=data_path_default, required=data_path_default is None, help="Path to the dataset file.")
+    parser.add_argument("--output_path", type=str, default=output_path_default, required=output_path_default is None, help="Directory to store cached outputs.")
+    parser.add_argument("--model_path", type=str, default=model_path_default, required=model_path_default is None, help="Path to the pretrained model.")
+    parser.add_argument("--tokenizer_path", type=str, default=env_str("TEST_CASES_GEN_TOKENIZER_PATH") or env_str("TOKENIZER_PATH", default=None), help="Path to the pretrained model.")
+    parser.add_argument("--dtype", type=str, default=env_str("TEST_CASES_GEN_DTYPE") or env_str("DTYPE", default="bfloat16"), help="Data type to use for the model (e.g., fp16, bf16, etc.).")
+    parser.add_argument("--n_gpus", type=int, default=env_int("TEST_CASES_GEN_N_GPUS", default=None) or env_int("N_GPUS", default=8), help="Number of GPUs to use for tensor parallelism.")
+    parser.add_argument("--temperature", type=float, default=env_float("TEST_CASES_GEN_TEMPERATURE", default=None) or env_float("TEMPERATURE", default=0.0), help="Sampling temperature for generation.")
+    parser.add_argument("--top_p", type=float, default=env_float("TEST_CASES_GEN_TOP_P", default=None) or env_float("TOP_P", default=1.0), help="Top-p sampling for generation.")
+    parser.add_argument("--top_k", type=int, default=env_int("TEST_CASES_GEN_TOP_K", default=None) or env_int("TOP_K", default=-1), help="Top-k sampling for generation.")  # todo: 40
+    parser.add_argument("--max_len", type=int, default=env_int("TEST_CASES_GEN_MAX_LEN", default=None) or env_int("MAX_LEN", default=2048), help="Maximum number of tokens to generate.")
+    parser.add_argument("--use_chat_template", type=str2bool, default=env_bool("TEST_CASES_GEN_USE_CHAT_TEMPLATE", default=None) or env_bool("USE_CHAT_TEMPLATE", default=False))
+    parser.add_argument("--seed", type=int, default=env_int("TEST_CASES_GEN_SEED", default=None) or env_int("SEED", default=42))
+    parser.add_argument("--enable_thinking", type=str2bool, default=env_bool("TEST_CASES_GEN_ENABLE_THINKING", default=None) or env_bool("ENABLE_THINKING", default=True))
 
     args = parser.parse_args()
 

--- a/test_cases_postprocess.py
+++ b/test_cases_postprocess.py
@@ -4,6 +4,8 @@ import re
 import os
 from tqdm import tqdm
 
+from env_config import load_env, env_str
+
 
 def extract_json_from_output(output_text):
     """
@@ -73,9 +75,14 @@ def get_after_think(text):
 
 
 def main():
+    load_env()
+
     parser = argparse.ArgumentParser(description="Process test cases and generate prompts for code evaluation.")
-    parser.add_argument("--input_file", type=str, required=True, help="Path to the input test case file.")
-    parser.add_argument("--output_file", type=str, required=True,  help="Path to the output file.")
+    # Namespaced env vars avoid collisions across scripts; unprefixed vars remain supported for compatibility.
+    input_file_default = env_str("TEST_CASES_POSTPROCESS_INPUT_FILE") or env_str("INPUT_FILE")
+    output_file_default = env_str("TEST_CASES_POSTPROCESS_OUTPUT_FILE") or env_str("OUTPUT_FILE")
+    parser.add_argument("--input_file", type=str, default=input_file_default, required=input_file_default is None, help="Path to the input test case file.")
+    parser.add_argument("--output_file", type=str, default=output_file_default, required=output_file_default is None,  help="Path to the output file.")
 
     args = parser.parse_args()
 

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,90 @@
+import os
+import unittest
+import types
+from unittest import mock
+
+
+def _with_env(env: dict):
+    """
+    Tiny helper to set env vars for a test and restore afterwards.
+    Use as: `with _with_env({...}): ...`
+    """
+    class _EnvCtx:
+        def __enter__(self):
+            self._old = {}
+            for k, v in env.items():
+                self._old[k] = os.environ.get(k)
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            for k, old in self._old.items():
+                if old is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = old
+
+    return _EnvCtx()
+
+
+class TestEnvConfig(unittest.TestCase):
+    def test_env_int_parses(self):
+        from env_config import env_int
+
+        with _with_env({"N_GPUS": "8"}):
+            self.assertEqual(env_int("N_GPUS"), 8)
+
+    def test_env_int_default_when_unset(self):
+        from env_config import env_int
+
+        with _with_env({"N_GPUS": None}):
+            self.assertEqual(env_int("N_GPUS", default=3), 3)
+
+    def test_env_float_parses(self):
+        from env_config import env_float
+
+        with _with_env({"TEMPERATURE": "0.8"}):
+            self.assertAlmostEqual(env_float("TEMPERATURE"), 0.8)
+
+    def test_env_bool_parses_truthy(self):
+        from env_config import env_bool
+
+        with _with_env({"DEBUG": "true"}):
+            self.assertTrue(env_bool("DEBUG"))
+
+    def test_env_bool_parses_falsy(self):
+        from env_config import env_bool
+
+        with _with_env({"DEBUG": "0"}):
+            self.assertFalse(env_bool("DEBUG"))
+
+    def test_env_present_empty_string_is_false(self):
+        from env_config import env_present
+
+        with _with_env({"MODEL_PATH": ""}):
+            self.assertFalse(env_present("MODEL_PATH"))
+
+    def test_env_bool_invalid_exits_cleanly(self):
+        from env_config import env_bool
+
+        with _with_env({"DEBUG": "maybe"}):
+            with self.assertRaises(SystemExit) as ctx:
+                env_bool("DEBUG")
+            self.assertIn("Invalid boolean environment variable DEBUG", str(ctx.exception))
+
+    def test_load_env_works_when_dotenv_available(self):
+        # Don't require python-dotenv to actually be installed in the test environment.
+        import env_config
+
+        fake_dotenv = types.SimpleNamespace(load_dotenv=lambda **kwargs: True)
+        with mock.patch.dict("sys.modules", {"dotenv": fake_dotenv}):
+            self.assertTrue(env_config.load_env())
+
+    def test_empty_string_treated_as_unset(self):
+        from env_config import env_str
+
+        with _with_env({"MODEL_PATH": ""}):
+            self.assertIsNone(env_str("MODEL_PATH"))

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -1,0 +1,93 @@
+import unittest
+import tempfile
+import os
+import sqlite3
+
+
+class TestValidateConfig(unittest.TestCase):
+    def test_missing_required(self):
+        from validate_config import validate_environ
+
+        errors = validate_environ({})
+        self.assertTrue(any("MODEL_PATH" in e for e in errors))
+        self.assertTrue(any("N_GPUS" in e for e in errors))
+        self.assertTrue(any("DATA_DIR" in e for e in errors))
+        self.assertTrue(any("OUTPUT_DIR" in e for e in errors))
+
+    def test_valid_minimal(self):
+        from validate_config import validate_environ
+
+        with tempfile.TemporaryDirectory() as td:
+            env = {
+                "MODEL_PATH": td,
+                "DATA_DIR": td,
+                "OUTPUT_DIR": td,
+                "N_GPUS": "1",
+            }
+            self.assertEqual(validate_environ(env), [])
+
+    def test_db_uri_sqlite_absolute_ok(self):
+        from validate_config import validate_environ
+
+        with tempfile.TemporaryDirectory() as td:
+            db_path = os.path.join(td, "test.sqlite3")
+            sqlite3.connect(db_path).close()
+
+            env = {
+                "MODEL_PATH": td,
+                "DATA_DIR": td,
+                "OUTPUT_DIR": td,
+                "N_GPUS": "1",
+                # sqlite:////abs/path
+                "DB_URI": f"sqlite:////{db_path.lstrip(os.sep)}",
+            }
+            self.assertEqual(validate_environ(env), [])
+
+    def test_db_uri_sqlite_relative_ok(self):
+        from validate_config import validate_environ
+
+        with tempfile.TemporaryDirectory() as td:
+            cwd = os.getcwd()
+            try:
+                os.chdir(td)
+                db_path = "rel.sqlite3"
+                sqlite3.connect(db_path).close()
+
+                env = {
+                    "MODEL_PATH": td,
+                    "DATA_DIR": td,
+                    "OUTPUT_DIR": td,
+                    "N_GPUS": "1",
+                    "DB_URI": f"sqlite:///{db_path}",
+                }
+                self.assertEqual(validate_environ(env), [])
+            finally:
+                os.chdir(cwd)
+
+    def test_db_uri_missing_scheme_errors(self):
+        from validate_config import validate_environ
+
+        with tempfile.TemporaryDirectory() as td:
+            env = {
+                "MODEL_PATH": td,
+                "DATA_DIR": td,
+                "OUTPUT_DIR": td,
+                "N_GPUS": "1",
+                "DB_URI": "not-a-uri",
+            }
+            errors = validate_environ(env)
+            self.assertTrue(any("DB_URI must include a scheme" in e for e in errors))
+
+    def test_namespaced_output_path_parent_missing_errors(self):
+        from validate_config import validate_environ
+
+        with tempfile.TemporaryDirectory() as td:
+            env = {
+                "MODEL_PATH": td,
+                "DATA_DIR": td,
+                "OUTPUT_DIR": td,
+                "N_GPUS": "1",
+                "SPLIT_MERGE_OUTPUT_PATH": os.path.join(td, "does-not-exist", "out.jsonl"),
+            }
+            errors = validate_environ(env)
+            self.assertTrue(any("SPLIT_MERGE_OUTPUT_PATH parent directory does not exist" in e for e in errors))

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import os
+import sys
+from typing import Mapping, List, Optional
+from urllib.parse import urlparse
+
+from env_config import load_env
+
+
+def _is_probably_path(value: str) -> bool:
+    # Heuristic: treat obvious filesystem-y strings as paths; otherwise assume a remote model id.
+    return (
+        value.startswith((".", "/", "~"))
+        or os.sep in value
+        or (os.altsep is not None and os.altsep in value)
+    )
+
+
+def _expand_path(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def _get(environ: Mapping[str, str], key: str) -> Optional[str]:
+    raw = environ.get(key)
+    if raw is None:
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
+def validate_environ(environ: Mapping[str, str]) -> List[str]:
+    """
+    Validate configuration values from an environment mapping.
+
+    Returns a list of human-readable error strings. Empty list means OK.
+    """
+    errors: List[str] = []
+
+    # Required keys
+    for key in ("MODEL_PATH", "N_GPUS", "DATA_DIR", "OUTPUT_DIR"):
+        if _get(environ, key) is None:
+            errors.append(f"{key} is required but not set")
+
+    # N_GPUS
+    n_gpus_raw = _get(environ, "N_GPUS")
+    if n_gpus_raw is not None:
+        try:
+            n_gpus = int(n_gpus_raw)
+            if n_gpus <= 0:
+                errors.append("N_GPUS must be an integer > 0")
+        except ValueError:
+            errors.append("N_GPUS must be an integer > 0")
+
+    # MODEL_PATH (path or model id)
+    model_path = _get(environ, "MODEL_PATH")
+    if model_path is not None and _is_probably_path(model_path):
+        mp = _expand_path(model_path)
+        if not os.path.exists(mp):
+            errors.append(f"MODEL_PATH does not exist: {mp}")
+        elif not os.path.isdir(mp):
+            errors.append(f"MODEL_PATH must be a directory: {mp}")
+        elif not os.access(mp, os.R_OK):
+            errors.append(f"MODEL_PATH is not readable: {mp}")
+
+    # TOKENIZER_PATH (optional; path or model id)
+    tokenizer_path = _get(environ, "TOKENIZER_PATH")
+    if tokenizer_path is not None and _is_probably_path(tokenizer_path):
+        tp = _expand_path(tokenizer_path)
+        if not os.path.exists(tp):
+            errors.append(f"TOKENIZER_PATH does not exist: {tp}")
+        elif not os.path.isdir(tp):
+            errors.append(f"TOKENIZER_PATH must be a directory: {tp}")
+        elif not os.access(tp, os.R_OK):
+            errors.append(f"TOKENIZER_PATH is not readable: {tp}")
+
+    # DATA_DIR / OUTPUT_DIR (directories)
+    for key in ("DATA_DIR", "OUTPUT_DIR"):
+        val = _get(environ, key)
+        if val is None:
+            continue
+        path = _expand_path(val)
+        if not os.path.exists(path):
+            errors.append(f"{key} does not exist: {path}")
+            continue
+        if not os.path.isdir(path):
+            errors.append(f"{key} must be a directory: {path}")
+            continue
+        if not os.access(path, os.R_OK):
+            errors.append(f"{key} is not readable: {path}")
+            continue
+        if key == "OUTPUT_DIR" and not os.access(path, os.W_OK):
+            errors.append(f"{key} is not writable: {path}")
+
+    # Script-specific paths (optional). Prefer namespaced keys; validate both to catch mistakes early.
+    data_path_keys = [
+        "DATA_PATH",
+        "SPLIT_MERGE_DATA_PATH",
+        "SELF_PLAY_DATA_PATH",
+        "TEST_CASES_GEN_DATA_PATH",
+        "SELF_PLAY_EVAL_DATA_PATH",
+        "PREPARE_SELF_PLAY_DATA_DATA_PATH",
+        "PREPARE_SFT_DATA_CODE_DATA_PATH",
+        "TEST_CASES_POSTPROCESS_INPUT_FILE",
+    ]
+    for key in data_path_keys:
+        data_path = _get(environ, key)
+        if data_path is None:
+            continue
+        dp = _expand_path(data_path)
+        if not os.path.exists(dp):
+            errors.append(f"{key} does not exist: {dp}")
+        elif not os.path.isfile(dp):
+            errors.append(f"{key} must be a file: {dp}")
+        elif not os.access(dp, os.R_OK):
+            errors.append(f"{key} is not readable: {dp}")
+
+    output_path_keys = [
+        "OUTPUT_PATH",
+        "SPLIT_MERGE_OUTPUT_PATH",
+        "SELF_PLAY_OUTPUT_PATH",
+        "TEST_CASES_GEN_OUTPUT_PATH",
+        "SELF_PLAY_EVAL_OUTPUT_PATH",
+        "PREPARE_SELF_PLAY_DATA_OUTPUT_PATH",
+        "PREPARE_SFT_DATA_CODE_OUTPUT_PATH",
+        "TEST_CASES_POSTPROCESS_OUTPUT_FILE",
+    ]
+    for key in output_path_keys:
+        output_path = _get(environ, key)
+        if output_path is None:
+            continue
+        op = _expand_path(output_path)
+        parent = os.path.dirname(op) or "."
+        parent = _expand_path(parent)
+        if not os.path.exists(parent):
+            errors.append(f"{key} parent directory does not exist: {parent}")
+        elif not os.path.isdir(parent):
+            errors.append(f"{key} parent is not a directory: {parent}")
+        elif not os.access(parent, os.W_OK):
+            errors.append(f"{key} parent directory is not writable: {parent}")
+
+    # Optional DB connection validation
+    db_uri = _get(environ, "DB_URI")
+    if db_uri is not None:
+        parsed = urlparse(db_uri)
+        if parsed.scheme == "sqlite":
+            # sqlite:////abs/path.db or sqlite:///rel/path.db
+            sqlite_path = parsed.path or ""
+            if db_uri.startswith("sqlite:////"):
+                # urlparse keeps the extra leading slash in path (e.g. '//var/db.sqlite3');
+                # if we feed that into sqlite3's file: URI it becomes 'file://var/..' (authority='var').
+                while sqlite_path.startswith("//"):
+                    sqlite_path = sqlite_path[1:]
+            else:
+                # sqlite:///relative.db -> parsed.path='/relative.db' (strip to make it relative)
+                sqlite_path = sqlite_path.lstrip("/")
+
+            sqlite_path = _expand_path(sqlite_path)
+            if not os.path.exists(sqlite_path):
+                errors.append(f"DB_URI sqlite file does not exist: {sqlite_path}")
+            else:
+                try:
+                    import sqlite3
+
+                    # Read-only open to avoid creating files during validation.
+                    sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True).close()
+                except Exception as e:
+                    errors.append(f"DB_URI sqlite connection failed: {e}")
+        else:
+            if not parsed.scheme:
+                errors.append("DB_URI must include a scheme, e.g. sqlite:///path/to.db")
+            elif not parsed.netloc and parsed.scheme not in {"sqlite"}:
+                errors.append("DB_URI must include a host, e.g. postgresql://user:pass@host:5432/db")
+
+    return errors
+
+
+def main() -> int:
+    load_env()
+    errors = validate_environ(os.environ)
+    if errors:
+        print("Configuration invalid:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+    print("Configuration OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `.env` file configuration support with environment variable loading helpers
- Add `validate_config.py` script for configuration validation
- Integrate env config into 9 entry-point Python scripts
- Add comprehensive unit tests

## Changes

### New Files
| File | Description |
|------|-------------|
| `.env.example` | Template configuration file with all environment variables documented |
| `env_config.py` | Utility module with `load_env()`, `env_str()`, `env_int()`, `env_float()`, `env_bool()`, `env_present()` helpers |
| `validate_config.py` | Configuration validation script (checks paths, permissions, types) |
| `tests/test_env_config.py` | Unit tests for env_config module |
| `tests/test_validate_config.py` | Unit tests for validation logic |

### Modified Files
| File | Changes |
|------|---------|
| `.gitignore` | Add `.env` to prevent committing local configuration |
| `README.md` | Add "Configuration" section with usage instructions |
| `infer_split_merge.py` | Integrate env config for all CLI arguments |
| `infer_self_play.py` | Integrate env config for all CLI arguments |
| `prepare_self_play_data.py` | Integrate env config for all CLI arguments |
| `prepare_sft_data_code.py` | Integrate env config for all CLI arguments |
| `self_play_eval.py` | Integrate env config for all CLI arguments |
| `test_cases_generation.py` | Integrate env config for all CLI arguments |
| `test_cases_postprocess.py` | Integrate env config for all CLI arguments |
| `deduplicate_problems.py` | Integrate env config for all CLI arguments |

## Usage

```bash
# 1. Copy the example env file
cp .env.example .env

# 2. Edit with your configuration
vim .env

# 3. Validate your setup
python validate_config.py

# 4. Run scripts (will use .env values as defaults)
python infer_split_merge.py  # no need to pass --model_path if set in .env
```

## Design Decisions

- **Precedence**: `CLI args > .env > code defaults`
- **Optional dependency**: Falls back gracefully if `python-dotenv` is not installed
- **Bidirectional fallback**: `N_SPLITS` / `NUM_SPLITS` are interchangeable for convenience
- **Error handling**: Invalid env values exit with clear messages (no stack traces)

Closes #10